### PR TITLE
Remove archived repos from stats dashboard

### DIFF
--- a/public/all.html
+++ b/public/all.html
@@ -93,8 +93,6 @@ footer {
 // Configuration: list of URLs of stats data to display in the tiles.
 const urls = [
   "agentic-lib-stats.json",
-  "repository0-crucible-stats.json",
-  "repository0-plot-code-lib-stats.json",
   "repository0-stats.json"
 ];
 


### PR DESCRIPTION
## Summary
- Remove `repository0-crucible` and `repository0-plot-code-lib` from the `public/all.html` stats dashboard
- These experiment repos have been archived and are no longer actively evolving
- Dashboard now shows only `agentic-lib` and `repository0` tiles

## Test plan
- [ ] Verify `public/all.html` loads with 2 tiles instead of 4
- [ ] Verify auto-reload cycles correctly between the 2 remaining tiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)