### PR TITLE
Add agentic-lib 7.1.2 as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "author": "https://github.com/xn-intenton-z2a",
   "license": "GPL-3.0, MIT",
   "dependencies": {
+    "@xn-intenton-z2a/agentic-lib": "^7.1.2",
     "dotenv": "^16.5.0",
     "express": "^4.21.2",
     "minimatch": "^10.0.1",


### PR DESCRIPTION
## Summary

- Add `@xn-intenton-z2a/agentic-lib: ^7.1.2` as a production dependency
- Fixes `init.yml` workflow which calls `npx @xn-intenton-z2a/agentic-lib init --purge` but fails with "could not determine executable to run" because the package wasn't a declared dependency

## Test plan

- [ ] Merge this PR
- [ ] Trigger `init` workflow — should now resolve the `agentic-lib` CLI binary
- [ ] Verify `npm update @xn-intenton-z2a/agentic-lib` step also works

🤖 Generated with [Claude Code](https://claude.com/claude-code)