### PR TITLE
Fix init.yml: use npx agentic-lib not npx @xn-intenton-z2a/agentic-lib

### DIFF
--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -44,7 +44,7 @@ jobs:
         run: npm update @xn-intenton-z2a/agentic-lib
 
       - name: Run init --purge
-        run: npx @xn-intenton-z2a/agentic-lib init --purge
+        run: npx agentic-lib init --purge
 
       - run: npm install
 
@@ -59,7 +59,7 @@ jobs:
           git config user.name "GitHub Actions[bot]"
           git add -A
           git diff --cached --quiet && echo "No changes" && exit 0
-          VERSION=$(npx @xn-intenton-z2a/agentic-lib version 2>/dev/null || echo "latest")
+          VERSION=$(npx agentic-lib version 2>/dev/null || echo "latest")
           git commit -m "init --purge (agentic-lib@${VERSION})"
           git push origin "$BRANCH"
 


### PR DESCRIPTION
## Summary

- `npx @xn-intenton-z2a/agentic-lib` fails because npx can't resolve binaries from scoped package names
- Change to `npx agentic-lib` which matches the `bin` field in the package

This is the direct fix — the init workflow has been failing on every run because of this.

## Test plan

- [ ] Merge, then trigger `init` workflow — should get past the `npx` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)