### PR TITLE
Add workflows: write permission to init.yml

### DIFF
--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -17,6 +17,7 @@ permissions:
   contents: write
   pull-requests: write
   packages: read
+  workflows: write
 
 jobs:
   init:


### PR DESCRIPTION
## Summary

Init copies workflow files to `.github/workflows/` which requires `workflows: write` on the GITHUB_TOKEN to push. Without it the push is rejected.

## Test plan

- [ ] Merge, trigger init — push should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)