### PR TITLE
Remove GitHub Packages auth from init.yml

### DIFF
--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -25,12 +25,6 @@ jobs:
         with:
           node-version: "24"
 
-      - name: Set up ~/.npmrc
-        run: |
-          echo "@xn-intenton-z2a:registry=https://npm.pkg.github.com" >> ~/.npmrc
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
-          echo "always-auth=true" >> ~/.npmrc
-
       - name: Create init branch
         run: |
           BRANCH="agentic-lib-init-$(date -u +%Y%m%d)"


### PR DESCRIPTION
## Summary

- Remove `.npmrc` setup for GitHub Packages from init.yml
- agentic-lib is moving to npmjs.org — no auth needed to install public packages

## Test plan

- [ ] Merge agentic-lib PR #1786 first (publishes to npmjs.org)
- [ ] Merge this, trigger init

🤖 Generated with [Claude Code](https://claude.com/claude-code)