### PR TITLE
Use WORKFLOW_TOKEN in init to push workflow files

### DIFF
--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.WORKFLOW_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- Use `WORKFLOW_TOKEN` (classic PAT with `workflow` scope) for checkout so git push can update `.github/workflows/` files
- Fixes: `refusing to allow a GitHub App to create or update workflow without workflows permission`

🤖 Generated with [Claude Code](https://claude.com/claude-code)