### PR TITLE
fix: broaden automerge branch prefix to agentic-lib-

### DIFF
--- a/.github/workflows/agent-flow-fix-code.yml
+++ b/.github/workflows/agent-flow-fix-code.yml
@@ -36,7 +36,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'check_suite' &&
        github.event.check_suite.conclusion == 'failure' &&
-       (startsWith(github.event.check_suite.head_branch, 'agentic-lib-issue-') ||
+       (startsWith(github.event.check_suite.head_branch, 'agentic-lib-') ||
         startsWith(github.event.check_suite.head_branch, 'copilot/')))
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/ci-automerge.yml
+++ b/.github/workflows/ci-automerge.yml
@@ -25,7 +25,7 @@ on:
 
 env:
   pullRequestLabel: "automerge"
-  branchPrefix: "agentic-lib-issue-"
+  branchPrefix: "agentic-lib-"
   copilotBranchPrefix: "copilot/"
 
 jobs:
@@ -240,7 +240,7 @@ jobs:
               branchName = pullRequest.head.ref;
               core.info(`branchName '${branchName}'`);
 
-              // Extract issue number from branch name (supports agentic-lib-issue-* and copilot/* prefixes)
+              // Extract issue number from branch name (supports agentic-lib-* and copilot/* prefixes)
               let issueNumberMatch = '';
               if (branchName.startsWith(branchPrefix)) {
                 issueNumberMatch = branchName.replace(branchPrefix, '');


### PR DESCRIPTION
## Summary
Widen `branchPrefix` from `agentic-lib-issue-` to `agentic-lib-` so automerge matches all suite-owned branches (init, issue, etc.).

This must be merged manually (first time) so that subsequent init PRs can automerge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)