### PR TITLE
Fix init to use fully-qualified npx package name

### DIFF
--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -37,7 +37,7 @@ jobs:
         run: npm update @xn-intenton-z2a/agentic-lib
 
       - name: Run init --purge
-        run: npx agentic-lib init --purge
+        run: npx @xn-intenton-z2a/agentic-lib init --purge
 
       - run: npm install
 
@@ -52,7 +52,7 @@ jobs:
           git config user.name "GitHub Actions[bot]"
           git add -A
           git diff --cached --quiet && echo "No changes" && exit 0
-          VERSION=$(npx agentic-lib version 2>/dev/null || echo "latest")
+          VERSION=$(npx @xn-intenton-z2a/agentic-lib version 2>/dev/null || echo "latest")
           git commit -m "init --purge (agentic-lib@${VERSION})"
           git push origin "$BRANCH"
 


### PR DESCRIPTION
## Summary
`npx agentic-lib init --purge` was silently running repository0's own `src/lib/main.js` instead of the SDK CLI, because the evolved `package.json` has a `bin` field that shadows the package name.

Changed to `npx @xn-intenton-z2a/agentic-lib init --purge` which always resolves to the dependency's binary.

## Root cause
The agentic transform workflow evolved repository0's `package.json` to include:
```json
"bin": { "agentic-lib": "src/lib/main.js" }
```
This caused `npx agentic-lib` to invoke the project's own script instead of the `@xn-intenton-z2a/agentic-lib` dependency. The script did nothing and exited 0, so init appeared to succeed but copied no files.

## Test plan
- [ ] Re-run init after merge — should see full file replacement including README

🤖 Generated with [Claude Code](https://claude.com/claude-code)